### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,16 @@
     },
     "require-dev": {
         "internations/kodierungsregelwerksammlung": "^0.35.0",
-        "phpunit/phpunit": "~6"
+        "phpunit/phpunit": "~7"
     },
     "autoload": {
-        "psr-0": {
-            "InterNations\\Component\\Solr\\Util": "src/",
-            "InterNations\\Component\\Solr\\ExpressionInterface": "src/"
+        "psr-4": {
+            "InterNations\\Component\\Solr\\": "src/InterNations/Component/Solr/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "InterNations\\Component\\Solr\\Tests\\": "tests/InterNations/Component/Solr/"
         }
     },
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,9 +3,7 @@
          convertErrorsToExceptions="true"
          convertWarningsToExceptions="true"
          convertNoticesToExceptions="true"
-         mapTestClassNameToCoveredClassName="true"
          bootstrap="vendor/autoload.php"
-         strict="true"
          verbose="true"
          colors="true"
          timeoutForLargeTests="100">
@@ -17,18 +15,16 @@
     </testsuites>
 
     <logging>
-        <log type="coverage-html" target="build/coverage" title="SolrUtils code coverage"
-             charset="UTF-8" yui="true" highlight="true"
+        <log type="coverage-html" target="build/coverage"
              lowUpperBound="35" highLowerBound="70"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 
     <filter>
-        <blacklist>
-            <directory suffix=".php">vendor/</directory>
-            <directory suffix=".php">tests/</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
     </filter>
 
     <php>


### PR DESCRIPTION
# Changed log

- Since the PHP package requires `php-7.1` version, it should upgrade `PHPUnit` to `~7` version semver.
- Using the `PSR-4` autoloading for `InterNations\\Component\\Solr\\` and `InterNations\\Component\\Solr\\Tests\\`.
- Removing some attributes on `phpunit.xml.dist` file because they're unused and invalid.

The PHPUnit warning messages are as follows:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 10:
  - Element 'phpunit', attribute 'strict': The attribute 'strict' is not allowed.

  Line 21:
  - Element 'log', attribute 'title': The attribute 'title' is not allowed.
  - Element 'log', attribute 'charset': The attribute 'charset' is not allowed.
  - Element 'log', attribute 'yui': The attribute 'yui' is not allowed.
  - Element 'log', attribute 'highlight': The attribute 'highlight' is not allowed.

  Line 23:
  - Element 'log', attribute 'logIncompleteSkipped': The attribute 'logIncompleteSkipped' is not allowed.

  Line 27:
  - Element 'blacklist': This element is not expected. Expected is ( whitelist ).
``` 