### PR TITLE
Opt out of named arguments for PHP 8.0

### DIFF
--- a/src/InterNations/Component/Solr/ExpressionInterface.php
+++ b/src/InterNations/Component/Solr/ExpressionInterface.php
@@ -3,6 +3,9 @@ namespace InterNations\Component\Solr;
 
 interface ExpressionInterface
 {
+    /** @no-named-arguments */
     public function isEqual(string $expr): bool;
+
+    /** @no-named-arguments */
     public function __toString(): string;
 }

--- a/src/InterNations/Component/Solr/Util.php
+++ b/src/InterNations/Component/Solr/Util.php
@@ -54,6 +54,7 @@ final class Util
      *
      * @param mixed $value
      * @return string|ExpressionInterface
+     * @no-named-arguments
      */
     public static function quote($value)
     {
@@ -71,6 +72,7 @@ final class Util
      *
      * @param mixed $value
      * @return string|ExpressionInterface
+     * @no-named-arguments
      */
     public static function sanitize($value)
     {
@@ -116,6 +118,7 @@ final class Util
      *
      * @param mixed $value
      * @return string|ExpressionInterface
+     * @no-named-arguments
      */
     public static function escape($value)
     {


### PR DESCRIPTION
Let’s communicate that we are not promising backwards-compatibility on argument names.