### PR TITLE
INDEV-10502 Adopt backwards compatibility checker

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Check coding style
         run: composer coding-style
+
+      - name: Check backward compatibility
+        run: composer backward-compatibility-check

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install PHP with extensions
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "internations/kodierungsregelwerksammlung": "~0.35",
         "phpunit/phpunit": "~7 || ~8 || ~9",
-        "roave/backward-compatibility-check": "^5.0.0"
+        "roave/backward-compatibility-check": "^3 || ^4 || ^5 || ^6"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,16 @@
     ],
     "scripts": {
         "tests": "phpunit",
-        "coding-style": "phpcs --standard=vendor/internations/kodierungsregelwerksammlung/ruleset.xml ./src/"
+        "coding-style": "phpcs --standard=vendor/internations/kodierungsregelwerksammlung/ruleset.xml ./src/",
+        "backward-compatibility-check": "roave-backward-compatibility-check"
     },
     "require": {
         "php": ">=7.1.3"
     },
     "require-dev": {
         "internations/kodierungsregelwerksammlung": "~0.35",
-        "phpunit/phpunit": "~7 || ~8 || ~9"
+        "phpunit/phpunit": "~7 || ~8 || ~9",
+        "roave/backward-compatibility-check": "^5.0.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Integrate https://github.com/Roave/BackwardCompatibilityCheck to make versioning determination more trivial.

@lstrojny PHP version checks for 7.2 and 7.3 don't pass. And i am still looking at that for some time, please guide me if you know the reason. 